### PR TITLE
[FIX] Multiple Collision behaviours wont execute on hit

### DIFF
--- a/Assets/Resources/Prefabs/Blocks/Block.prefab
+++ b/Assets/Resources/Prefabs/Blocks/Block.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 4205123141860245065}
   - component: {fileID: 258504909998533141}
   - component: {fileID: 8638455681782496722}
+  - component: {fileID: 1357396478241080401}
   m_Layer: 0
   m_Name: Block
   m_TagString: Block
@@ -149,3 +150,15 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.1, y: 0.32}
   m_EdgeRadius: 0
+--- !u!114 &1357396478241080401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5284649261403713773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7f1059cceff0474ca2a1d60b70aff55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Blocks/BlockBehaviours/BlockDestructionCoordinator.cs
+++ b/Assets/Scripts/Blocks/BlockBehaviours/BlockDestructionCoordinator.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Assets.Scripts.Blocks
+{
+    public class DestructionCoordinator : MonoBehaviour
+    {
+        private bool _isDestroying = false;
+        private readonly List<IEnumerator> _destructionCoroutines = new();
+
+        public void RegisterCoroutine(IEnumerator coroutine)
+        {
+            _destructionCoroutines.Add(coroutine);
+        }
+
+        public void TriggerDestruction()
+        {
+            if (_isDestroying) return;
+            _isDestroying = true;
+            StartCoroutine(RunDestruction());
+        }
+
+        private IEnumerator RunDestruction()
+        {
+            while (true)
+            {
+                var routines = new List<IEnumerator>(_destructionCoroutines);
+                _destructionCoroutines.Clear();
+
+                foreach (var routine in routines)
+                    yield return StartCoroutine(routine);
+
+                if (_destructionCoroutines.Count == 0)
+                    break;
+            }
+
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Blocks/BlockBehaviours/BlockDestructionCoordinator.cs.meta
+++ b/Assets/Scripts/Blocks/BlockBehaviours/BlockDestructionCoordinator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7f1059cceff0474ca2a1d60b70aff55

--- a/Assets/Scripts/Blocks/BlockBehaviours/ExplodeBehaviour.cs
+++ b/Assets/Scripts/Blocks/BlockBehaviours/ExplodeBehaviour.cs
@@ -24,7 +24,7 @@ namespace Assets.Scripts.Blocks
 
         public void OnCollisionExecute(Block context, Collision2D collision)
         {
-            Explode(context);
+            RegisterAndTrigger(context);
         }
 
         public void Explode(Block context)
@@ -73,6 +73,13 @@ namespace Assets.Scripts.Blocks
             }
             _soundPlayer.PlaySfx(_explodeClip);
             DestroyBlock(ctx);
+        }
+
+        public void RegisterAndTrigger(Block context)
+        {
+            var coordinator = context.GetComponent<DestructionCoordinator>();
+            coordinator.RegisterCoroutine(ExplosionSequence(context));
+            coordinator.TriggerDestruction();
         }
 
         public void DestroyBlock(Block context)

--- a/Assets/Scripts/Blocks/BlockBehaviours/Interfaces/IDestructableBehaviour.cs
+++ b/Assets/Scripts/Blocks/BlockBehaviours/Interfaces/IDestructableBehaviour.cs
@@ -3,6 +3,7 @@ namespace Assets.Scripts.Blocks
     public interface IDestructableBehaviour
     {
         public void AdjustBlockCounter();
-        void DestroyBlock(Block context);
+        public void DestroyBlock(Block context);
+        public void RegisterAndTrigger(Block context); // Register and trigger destruction
     }
 }

--- a/Assets/Scripts/Blocks/BlockBehaviours/SlowBehaviour.cs
+++ b/Assets/Scripts/Blocks/BlockBehaviours/SlowBehaviour.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Assets.Scripts.Ball;
 using Assets.Scripts.SharedKernel;
 using UnityEngine;
@@ -30,10 +31,23 @@ namespace Assets.Scripts.Blocks
                 ballController.StartCoroutine(RestoreSpeedAfterDelay(ballRigidbody, ballController, originalVelocity, _delay));
             }
 
-            DestroyBlock(context);
+            RegisterAndTrigger(context);
         }
 
-        private System.Collections.IEnumerator RestoreSpeedAfterDelay(Rigidbody2D rb, BallController controller, Vector2 originalVelocity, float delay)
+        public void RegisterAndTrigger(Block context)
+        {
+            var coordinator = context.GetComponent<DestructionCoordinator>();
+            coordinator.RegisterCoroutine(SlowDestroy(context));
+            coordinator.TriggerDestruction();
+        }
+
+        private IEnumerator SlowDestroy(Block context)
+        {
+            yield return null;
+            AdjustBlockCounter();
+        }
+
+        private IEnumerator RestoreSpeedAfterDelay(Rigidbody2D rb, BallController controller, Vector2 originalVelocity, float delay)
         {
             yield return new WaitForSecondsRealtime(delay);
 

--- a/Assets/Scripts/Level/LevelDesigner.cs
+++ b/Assets/Scripts/Level/LevelDesigner.cs
@@ -40,6 +40,8 @@ namespace Assets.Scripts.Level
                 3 => GetLevel3(),
                 4 => GetLevel4(),
                 5 => GetLevel5(),
+                6 => GetLevel6(),
+                7 => GetLevel7(),
                 _ => GetLevel1()
             };
         }
@@ -151,6 +153,50 @@ namespace Assets.Scripts.Level
                     builder.WithBlock(new float2(x * s, y * s), exploder);
                 }
             }
+
+            return builder.Build();
+        }
+
+        private LevelData GetLevel6()
+        {
+            var slower = new BehaviourBuilder()
+                .Add<SlowBehaviour, SlowConfig>(
+                    new SlowConfig(2f, 0.3f)
+                )
+                .Build();
+
+            var reflector = new BehaviourBuilder()
+                .Add<ReflectBehaviour, ReflectConfig>(
+                    new ReflectConfig(Vector2.up)
+                )
+                .Build();
+
+            var builder = new LevelBuilder();
+
+            // Horizontal reflector line
+            foreach (var pos in GenerateXCoords(-4f, 4f, 0f))
+                builder.WithBlock(new float2(pos.x, pos.y), reflector);
+
+            // Vertical slow line
+            foreach (var pos in GenerateYCoords(3f, -3f, 0f))
+                builder.WithBlock(new float2(pos.x, pos.y), slower);
+
+            return builder.Build();
+        }
+
+        private LevelData GetLevel7()
+        {
+            var combo = new BehaviourBuilder()
+                .Add<SlowBehaviour, SlowConfig>(
+                    new SlowConfig(1.5f, 0.4f)
+                )
+                .AddNonConfigurable<ExplodeBehaviour>()
+                .Build();
+
+            var builder = new LevelBuilder();
+
+            foreach (var pos in GenerateGrid(-2f, 2f, 0.4f, 2f, -2f, 0.4f))
+                builder.WithBlock(new float2(pos.x, pos.y), combo);
 
             return builder.Build();
         }

--- a/Assets/Scripts/Level/StaticLevelCatalog.cs
+++ b/Assets/Scripts/Level/StaticLevelCatalog.cs
@@ -10,7 +10,9 @@ namespace Assets.Scripts.Level
             new LevelDefinition(2, "Moving Challenge"),
             new LevelDefinition(3, "Explosion performance test"),
             new LevelDefinition(4, "Reflect behaviour test"),
-            new LevelDefinition(5, "Slower madness")
+            new LevelDefinition(5, "Slower madness"),
+            new LevelDefinition(6, "Slow & Reflect Cross Pattern"),
+            new LevelDefinition(7, "Slow + Explode Combo Grid")
         };
 
         public IReadOnlyList<LevelDefinition> GetAvailableLevels() => _levels;


### PR DESCRIPTION
## Description

Added `BlockDestructionCoordinator` to handle destruction of the block. 

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (describe):

## Checklist

- [X] My code follows the Unity C# coding standards.
- [X] I have tested my changes in the Unity Editor.
- [X] I have added/updated relevant documentation and comments.
- [X] No errors or warnings in the Unity Console.
- [X] All new and existing tests pass.

## How to Test

Describe the steps to test your changes:

1. Play level 7 with slow + explosion blocks
2. Both behavours should be executed on ball hit.

## Related Issues

Closes #93 