### PR TITLE
Resolve: Add powerups functionality

### DIFF
--- a/Assets/Scenes/Level0.unity
+++ b/Assets/Scenes/Level0.unity
@@ -5145,12 +5145,24 @@ PrefabInstance:
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 697293219477396324, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
+      propertyPath: m_Mass
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 697293219477396324, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
       propertyPath: m_BodyType
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 697293219477396324, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
+      propertyPath: m_Constraints
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 697293219477396324, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
       propertyPath: m_GravityScale
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 697293219477396324, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
+      propertyPath: m_CollisionDetection
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 702405139730017999, guid: de0992f14535cb64d8660de9baeba94b, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -40,34 +40,29 @@ public class PlayerController : MonoBehaviour
 
     void FixedUpdate()
     {
-        ArcadeSteering();
-        ClampToVerticalBounds();
+        ManuelSteering();
     }
 
-    private void SimulatedSteering()
+    private void ManuelSteering()
     {
-        float currentYSpeed = _rb.linearVelocity.y;
+        if (_movementVector.y == 0f) return;
 
-        float targetYSpeed = _movementVector.y * _paddle.Speed;
-        float smoothing = _paddle.Acceleration;
+        Vector3 pos = transform.position;
 
-        _rb.linearVelocityY = Mathf.Lerp(currentYSpeed, targetYSpeed, smoothing * Time.fixedDeltaTime);
+        float deltaY = _movementVector.y * _paddle.Speed * Time.fixedDeltaTime;
+        pos.y += deltaY;
 
+        float camHeight = Camera.main.orthographicSize;
+        float hudOffset = LevelBounds.GetHudOffsetInUnits();
+        float halfPaddleHeight = _paddlePrefab.GetComponent<SpriteRenderer>().bounds.extents.y;
+
+        float upperBound = camHeight - hudOffset - halfPaddleHeight;
+        float lowerBound = -camHeight + halfPaddleHeight;
+
+        pos.y = Mathf.Clamp(pos.y, lowerBound, upperBound);
+        _rb.MovePosition(pos); // this works with kinematic too
     }
 
-    private void ArcadeSteering()
-    {
-        float currentYSpeed = _rb.linearVelocity.y;
-
-        if (_movementVector.y == 0)
-            _rb.linearVelocityY = 0f;
-        else
-        {
-            float targetYSpeed = _movementVector.y * _paddle.Speed;
-            float newYSpeed = Mathf.MoveTowards(currentYSpeed, targetYSpeed, _paddle.Acceleration * Time.fixedDeltaTime);
-            _rb.linearVelocityY = newYSpeed;
-        }
-    }
 
     public void OnLaunchBall(InputAction.CallbackContext ctx)
     {
@@ -120,6 +115,7 @@ public class PlayerController : MonoBehaviour
         _paddle.Action(ctx);
     }
 
+    [Obsolete("Not used any more", true)]
     private void ClampToVerticalBounds()
     {
         Vector3 pos = transform.position;
@@ -132,6 +128,33 @@ public class PlayerController : MonoBehaviour
         float lowerBound = -camHeight + halfPaddleHeight;
 
         pos.y = Mathf.Clamp(pos.y, lowerBound, upperBound);
-        transform.position = pos;
+        _rb.position = pos;
+    }
+
+    [Obsolete("Not used any more", true)]
+    private void SimulatedSteering()
+    {
+        float currentYSpeed = _rb.linearVelocity.y;
+
+        float targetYSpeed = _movementVector.y * _paddle.Speed;
+        float smoothing = _paddle.Acceleration;
+
+        _rb.linearVelocityY = Mathf.Lerp(currentYSpeed, targetYSpeed, smoothing * Time.fixedDeltaTime);
+
+    }
+
+    [Obsolete("Not used any more", true)]
+    private void ArcadeSteering()
+    {
+        float currentYSpeed = _rb.linearVelocity.y;
+
+        if (_movementVector.y == 0)
+            _rb.linearVelocityY = 0f;
+        else
+        {
+            float targetYSpeed = _movementVector.y * _paddle.Speed;
+            float newYSpeed = Mathf.MoveTowards(currentYSpeed, targetYSpeed, _paddle.Acceleration * Time.fixedDeltaTime);
+            _rb.linearVelocityY = newYSpeed;
+        }
     }
 }

--- a/Assets/Scripts/Powerups/SpeedBoost.cs
+++ b/Assets/Scripts/Powerups/SpeedBoost.cs
@@ -11,9 +11,9 @@ namespace Assets.Scripts.Powerups
         private float _originalSpeed;
         private float _originalAcceleration;
         private float _duration;
-        private const float _defaultMultiplier = 10f;
+        private const float _defaultMultiplier = 2f;
         private const float _defaultDuration = 5f;
-        private const float _defaultAcceleration = 30f;
+        private const float _defaultAcceleration = 20f;
 
         public override void Configure(object config)
         {

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 19
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -16,21 +17,21 @@ PhysicsManager:
   m_EnableAdaptiveForce: 0
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
-  m_ContactsGeneration: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
   m_ClothGravity: {x: 0, y: -9.81, z: 0}
-  m_ContactPairsMode: 0
+  m_ContactPairsMode: 3
   m_BroadphaseType: 0
-  m_WorldBounds:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 250, y: 250, z: 250}
-  m_WorldSubdivisions: 8
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
-  m_EnableUnifiedHeightmaps: 1
+  m_ImprovedPatchFriction: 0
+  m_GenerateOnTriggerStayEvents: 1
   m_SolverType: 0
   m_DefaultMaxAngularSpeed: 50
+  m_ScratchBufferChunkCount: 4
+  m_CurrentBackendId: 4072204805
+  m_FastMotionThreshold: 3.4028235e+38


### PR DESCRIPTION
## Description

Added `PowerupBase`, `PowerupSpawner `and `PoewrupExpirationCoordinator` to handle powerup functionality. Also added SpeedBoost as first powerup showcase. Fixed level boundaries problem. Also adde `PowerupUI `to showcase active powerups in HUD.

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (describe):

## Checklist

- [X] My code follows the Unity C# coding standards.
- [X] I have tested my changes in the Unity Editor.
- [X] I have added/updated relevant documentation and comments.
- [X] No errors or warnings in the Unity Console.
- [X] All new and existing tests pass.

## How to Test

Describe the steps to test your changes:

1. Start game, press `SPACE` to enable speed boost.
2. Observe HUD showcasing enabled boost.
3. Observe incerased speed of the paddle.

## Related Issues

Closes #56
Closes #102 

## Additional Notes

Add any other context or screenshots here.